### PR TITLE
Adding explaination for Binance symbol

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 ## Instructions:
 1. Specify your settings in the `accountData.json` file
     - **number**: an arbitrary number you want to give to your account (_1, 2, 3, etc_)
-    - **exchange**: binance or bybit
+    - **exchange**: binance** or bybit
     - **name**: an arbitrary number you want to give to your account (_myCoolAccount1_)
     - **key**: your account API key. Best practice is to create a separate Read-Only key for this.
     - **secret**: your account API secret
@@ -24,6 +24,8 @@
 6. _Submit any issues or enhancement ideas on the [Issues](https://github.com/daisy613/accountData/issues) page._
 
 _* for Binance COIN-M or Bybit, create a separate account entry in the settings file per each asset and make sure to specify the asset in the `Symbol` field._
+
+_** for Binance, leave **symbol** empty for USD-M Futures or use `"COIN-M"` for COIN-M Futures_
 
 ## Tips:
 - USDT (TRC20): TNuwZebdZmoDxrJRxUbyqzG48H4KRDR7wB


### PR DESCRIPTION
I've been trying to set up the script and had some hard time figuring out the value I had to use for `symbol` and `binance`.

After reading the code, I could see that if the symbol is empty, this gathers the data from `USD-M`. As I thought it was not clear to me, I propose here a modification to the README to try to make it more clear to other users.

We could also propose a modification to the code to allow the values `USD-M` and `COIN-M` when `binance` is used. I didn't want to do modification without your approval therefore I do the first version of the proposed modification.

Thanks for the script